### PR TITLE
Fix bug due to upstream update of black.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-black>=18.9b0
+black>=19.3b0
 loguru>=0.2.5

--- a/src/blackbook/__init__.py
+++ b/src/blackbook/__init__.py
@@ -28,9 +28,7 @@ def format_notebook_content(path: pathlib.Path) -> Optional[dict]:
 
                 try:  # Some ipynb files will not have valid source code
                     string = "".join(cell["source"])
-                    formatted_string = black.format_str(
-                        string, line_length=black.DEFAULT_LINE_LENGTH
-                    )
+                    formatted_string = black.format_str(string, mode=black.FileMode())
                     if formatted_string != string:
                         modification_found = True
                         cell["source"] = [

--- a/src/blackbook/__init__.py
+++ b/src/blackbook/__init__.py
@@ -1,8 +1,7 @@
-from typing import Iterator, Optional
-
-import re
-import pathlib
 import json
+import pathlib
+import re
+from typing import Iterator, Optional
 
 import black
 


### PR DESCRIPTION
`format_str` no longer takes a line length argument but an instance of a
class.


@daffidwilde @Nikoleta-v3 if either of you could merge and do a new release that'd be great, otherwise my PyData ⚡️ talk won't happen...