### PR TITLE
Add CI with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI/CD
+
+on:
+  push:
+  pull_request:
+  # Run daily at 0:01 UTC
+  schedule:
+  - cron:  '1 0 * * *'
+
+jobs:
+  test:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1.1.1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install -q --no-cache-dir -e .
+        python -m pip install -q --no-cache-dir "mypy==0.660" pytest pytest-cov isort coveralls
+        python -m pip list
+    - name: Lint with mypy
+      if: matrix.python-version == 3.7 && matrix.os == 'ubuntu-latest'
+      run: |
+        mypy src --ignore-missing-imports
+    - name: Lint with Black
+      if: matrix.python-version == 3.7 && matrix.os == 'ubuntu-latest'
+      run: |
+        black --check --diff --verbose .
+    - name: Lint imports with isort
+      if: matrix.python-version == 3.7 && matrix.os == 'ubuntu-latest'
+      run: |
+        isort -rc . --check-only
+    - name: Test with pytest
+      run: |
+        python -m pytest -s
+    - name: Lint with blackbook
+      # Needs to go last, else pytest will fail
+      if: matrix.python-version == 3.7 && matrix.os == 'ubuntu-latest'
+      run: |
+        blackbook .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install -q --no-cache-dir -e .
-        python -m pip install -q --no-cache-dir "mypy==0.660" pytest pytest-cov isort coveralls
+        python -m pip install -q --no-cache-dir "mypy==0.750" pytest pytest-cov isort coveralls
         python -m pip list
     - name: Lint with mypy
       if: matrix.python-version == 3.7 && matrix.os == 'ubuntu-latest'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 
 install:
   - python setup.py develop
-  - pip install mypy==0.660
+  - pip install mypy==0.750
   - pip install pytest
   - pip install pytest-cov
   - pip install isort

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,7 @@ install:
   - pip install coveralls
 
 script:
-  - pytest .
-  - pytest --cov=blackbook tests
+  - python -m pytest -r sx
   - mypy src --ignore-missing-imports
   - black . --check
   - isort -rc . --check-only

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/Nikoleta-v3/blackbook.svg?branch=master)](https://travis-ci.org/Nikoleta-v3/blackbook)
+[![GitHub Actions Status: CI](https://github.com/Nikoleta-v3/blackbook/workflows/CI/CD/badge.svg)](https://github.com/Nikoleta-v3/blackbook/actions?query=workflow%3ACI%2FCD+branch%3Amaster)
 [![Coverage Status](https://coveralls.io/repos/github/Nikoleta-v3/blackbook/badge.svg?branch=add-coverage-badge)](https://coveralls.io/github/Nikoleta-v3/blackbook?branch=add-coverage-badge)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.2553363.svg)](https://doi.org/10.5281/zenodo.2553363)
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --ignore=setup.py --cov=blackbook --cov-report=term-missing


### PR DESCRIPTION
Resolves #32 

Adds testing for Python 3.6, Python 3.7, and Python 3.8 across Ubuntu and MacOS. Additionally add `pytest.ini` for simplified calls and add GitHub Acitons CI status badge to `README`.

```
* Add CI with GitHub Actions
   - Runs on push and pull request events, as well as a daily CRON job at 0:01 UTC
* Add pytest.ini
* Update mypy release version
```