### PR TITLE
feat: Add ability to run on single notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,16 @@
 ```bash
 $ pip install blackbook
 $ blackbook .
-2019-01-28 17:15:10.857 | INFO     | blackbook.__main__:main:25 - All done! 📖
-2019-01-28 17:15:10.857 | INFO     | blackbook.__main__:main:27 - 1 notebooks
-reformatted. 1 left unchanged.
+2019-01-28 17:15:10.857 | INFO     | blackbook.__main__:main:31 - All done! 📖
+2019-01-28 17:15:10.857 | INFO     | blackbook.__main__:main:33 - 1 notebooks reformatted. 1 left unchanged.
+```
+
+You can also run `blackbook` over a single notebook
+
+```bash
+$ blackbook unformatted.ipynb
+2019-01-28 17:15:12.663 | INFO     | blackbook.__main__:main:31 - All done! 📖
+2019-01-28 17:15:12.663 | INFO     | blackbook.__main__:main:33 - 1 notebooks reformatted. 0 left unchanged.
 ```
 
 ## Why?

--- a/src/blackbook/__main__.py
+++ b/src/blackbook/__main__.py
@@ -10,6 +10,8 @@ import blackbook
 def main(path: pathlib.Path = None) -> None:
     if path is None:  # pragma: no cover
         path = pathlib.Path(sys.argv[1])
+    if not path.exists():
+        raise OSError(f"The path {path} is invalid.")
 
     count = 0
     reformatted_count = 0

--- a/src/blackbook/__main__.py
+++ b/src/blackbook/__main__.py
@@ -15,7 +15,11 @@ def main(path: pathlib.Path = None) -> None:
 
     count = 0
     reformatted_count = 0
-    for notebook_path in blackbook.gen_notebook_files_in_dir(path):
+
+    notebooks = (
+        [path] if path.suffix == ".ipynb" else blackbook.gen_notebook_files_in_dir(path)
+    )
+    for notebook_path in notebooks:
         nb = blackbook.format_notebook_content(notebook_path)
 
         if nb is not None:  # pragma: no cover

--- a/tests/test_format_notebook_content.py
+++ b/tests/test_format_notebook_content.py
@@ -1,5 +1,6 @@
 import json
 import pathlib
+import shutil
 
 import blackbook
 
@@ -16,6 +17,43 @@ def test_format_notebook_content():
         [
             cell["source"] == expected_cell["source"]
             for cell, expected_cell in zip(output_json["cells"], expected_json["cells"])
+        ]
+    )
+
+
+def test_format_single_notebook():
+    """
+    Test formatting a single notebook in an directory of unformatted notebooks
+    formats only that notebook
+    """
+    data_path = pathlib.Path(f"{__file__}").parent / "data"
+    source_notebook_path = data_path / "unformatted" / "spaces.ipynb"
+    copy_notebook_path = data_path / "unformatted" / "spaces_copy.ipynb"
+    shutil.copy(str(source_notebook_path), str(copy_notebook_path))
+
+    source_json = json.loads(source_notebook_path.read_text())
+    copy_json = json.loads(copy_notebook_path.read_text())
+
+    assert all(
+        [
+            copy_cell["source"] == source_cell["source"]
+            for copy_cell, source_cell in zip(copy_json["cells"], source_json["cells"])
+        ]
+    )
+
+    # Have to run blackbook main to show spaces_copy.ipynb is unaffected
+    blackbook.__main__.main(source_notebook_path)
+    output_json = json.loads(source_notebook_path.read_text())
+    check_copy_json = json.loads(copy_notebook_path.read_text())
+    shutil.copy(str(copy_notebook_path), str(source_notebook_path))
+    pathlib.Path.unlink(copy_notebook_path)
+
+    assert not all(
+        [
+            formatted_cell["source"] == unformatted_cell["source"]
+            for formatted_cell, unformatted_cell in zip(
+                output_json["cells"], check_copy_json["cells"]
+            )
         ]
     )
 

--- a/tests/test_format_notebook_content.py
+++ b/tests/test_format_notebook_content.py
@@ -45,6 +45,7 @@ def test_format_single_notebook():
     blackbook.__main__.main(source_notebook_path)
     output_json = json.loads(source_notebook_path.read_text())
     check_copy_json = json.loads(copy_notebook_path.read_text())
+    # Revert to pre-format state: unformat source notebook and delete copy
     shutil.copy(str(copy_notebook_path), str(source_notebook_path))
     pathlib.Path.unlink(copy_notebook_path)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,7 @@
 import pathlib
 
+import pytest
+
 from blackbook.__main__ import main
 
 
@@ -7,3 +9,9 @@ def test_main_runs_without_failure():
     data_path = pathlib.Path(f"{__file__}").parent / "data" / "formatted"
 
     assert main(data_path) is None
+
+
+def test_invalid_path():
+    with pytest.raises(OSError):
+        data_path = pathlib.Path(f"{__file__}").parent / "invalid"
+        main(data_path)


### PR DESCRIPTION
Resolves #31 

Add ability to specify the path of a single Jupyter notebook and then format only that notebook. Additionally, check before doing anything that the path given actually is a valid path. Additionally, add tests.

```
* Add check that given path is valid
* Allow for path to a single Jupyter notebook to be used for formatting
* Add tests for invalid path and for single notebook formatting
* Add example to README
```