### PR TITLE
refactor: Remove trailing newlines

### DIFF
--- a/src/blackbook/__init__.py
+++ b/src/blackbook/__init__.py
@@ -32,11 +32,9 @@ def format_notebook_content(path: pathlib.Path) -> Optional[dict]:
                     ).strip()  # Remove trailing newlines
                     if formatted_string != string:
                         modification_found = True
-                        cell_lines = formatted_string.splitlines()
-                        n_last_newline = len(cell_lines) - 1
-                        cell["source"] = [
-                            line + "\n" if itr < n_last_newline else line
-                            for itr, line in enumerate(cell_lines)
+                        cell["source"] = formatted_string.splitlines()
+                        cell["source"][:-1] = [
+                            line + "\n" for line in cell["source"][:-1]
                         ]
 
                 except black.InvalidInput:

--- a/src/blackbook/__init__.py
+++ b/src/blackbook/__init__.py
@@ -27,12 +27,17 @@ def format_notebook_content(path: pathlib.Path) -> Optional[dict]:
 
                 try:  # Some ipynb files will not have valid source code
                     string = "".join(cell["source"])
-                    formatted_string = black.format_str(string, mode=black.FileMode())
+                    formatted_string = black.format_str(
+                        string, mode=black.FileMode()
+                    ).strip()  # Remove trailing newlines
                     if formatted_string != string:
                         modification_found = True
+                        cell_lines = formatted_string.splitlines()
+                        n_last_newline = len(cell_lines) - 1
                         cell["source"] = [
-                            s + "\n" for s in formatted_string.split("\n")
-                        ][:-1]
+                            line + "\n" if itr < n_last_newline else line
+                            for itr, line in enumerate(cell_lines)
+                        ]
 
                 except black.InvalidInput:
                     pass

--- a/tests/data/formatted/spaces.ipynb
+++ b/tests/data/formatted/spaces.ipynb
@@ -14,7 +14,7 @@
    "outputs": [],
    "source": [
     "def function(a, b, c):\n",
-    "    return a + b + c\n"
+    "    return a + b + c"
    ]
   }
  ],


### PR DESCRIPTION
Resolves #25 

As it is desired to keep each line in the cell its own string, the cell source is set to be a list where each item in the list is a line of the cell truncated with a `\n` except for the last line.

```
* Remove trailing newlines from formatted notebook cells
* Remove newline from test comparison notebook to match behavior
```